### PR TITLE
ISPN-14002

### DIFF
--- a/multimap/src/main/java/org/infinispan/multimap/api/embedded/MultimapCacheManager.java
+++ b/multimap/src/main/java/org/infinispan/multimap/api/embedded/MultimapCacheManager.java
@@ -2,6 +2,7 @@ package org.infinispan.multimap.api.embedded;
 
 import org.infinispan.commons.util.Experimental;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.multimap.configuration.MultimapConfiguration;
 
 @Experimental
 public interface MultimapCacheManager<K, V> {
@@ -15,8 +16,12 @@ public interface MultimapCacheManager<K, V> {
     * @param name          name of multimap cache whose configuration is being defined
     * @param configuration configuration overrides to use
     * @return a cloned configuration instance
+    * @deprecated since 14
     */
+   @Deprecated
    Configuration defineConfiguration(String name, Configuration configuration);
+
+   Configuration defineConfiguration(String name, MultimapConfiguration configuration);
 
    /**
     * Retrieves a named multimap cache from the system.

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/Attribute.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/Attribute.java
@@ -1,0 +1,39 @@
+package org.infinispan.multimap.configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum Attribute {
+    // must be first
+    UNKNOWN(null),
+    SUPPORTS_DUPLICATES("supports-duplicates"),
+    NAME("name");
+    private static final Map<String, Attribute> ATTRIBUTES;
+
+    static {
+        final Map<String, Attribute> map = new HashMap<>(64);
+        for (Attribute attribute : values()) {
+            final String name = attribute.name;
+            if (name != null) {
+                map.put(name, attribute);
+            }
+        }
+        ATTRIBUTES = map;
+    }
+
+    private final String name;
+
+    Attribute(final String name) {
+        this.name = name;
+    }
+
+    public static Attribute forName(String localName) {
+        final Attribute attribute = ATTRIBUTES.get(localName);
+        return attribute == null ? UNKNOWN : attribute;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/Attribute.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/Attribute.java
@@ -6,7 +6,8 @@ import java.util.Map;
 public enum Attribute {
     // must be first
     UNKNOWN(null),
-    SUPPORTS_DUPLICATES("supports-duplicates");
+    SUPPORTS_DUPLICATES("supports-duplicates"),
+    NAME("name");
     private static final Map<String, Attribute> ATTRIBUTES;
 
     static {

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/Attribute.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/Attribute.java
@@ -6,8 +6,7 @@ import java.util.Map;
 public enum Attribute {
     // must be first
     UNKNOWN(null),
-    SUPPORTS_DUPLICATES("supports-duplicates"),
-    NAME("name");
+    SUPPORTS_DUPLICATES("supports-duplicates");
     private static final Map<String, Attribute> ATTRIBUTES;
 
     static {

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
@@ -1,0 +1,38 @@
+package org.infinispan.multimap.configuration;
+
+import org.infinispan.commons.configuration.attributes.AttributeDefinition;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
+
+public class MultimapConfiguration {
+
+    static final AttributeDefinition<String> NAME = AttributeDefinition.builder(Attribute.NAME, null, String.class)
+            .validator(value -> {
+                if (value == null) {
+                    try {
+                        throw new Exception("Missing name");
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            })
+            .immutable()
+            .build();
+
+    final AttributeSet attributes;
+
+    MultimapConfiguration(AttributeSet attributes) {
+        this.attributes = attributes;
+    }
+
+    static AttributeSet attributeDefinitionSet() {
+        return new AttributeSet(MultimapConfiguration.class, NAME);
+    }
+
+    final AttributeSet attributes() {
+        return attributes;
+    }
+
+    public String name() {
+        return attributes.attribute(NAME).get();
+    }
+}

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
@@ -7,23 +7,11 @@ public class MultimapConfiguration {
 
     public static final AttributeDefinition<Boolean> SUPPORTS_DUPLICATES = AttributeDefinition.builder(Attribute.SUPPORTS_DUPLICATES, false, Boolean.class)
             .immutable().build();
-    static final AttributeDefinition<String> NAME = AttributeDefinition.builder(Attribute.NAME, null, String.class)
-            .validator(value -> {
-                if (value == null) {
-                    throw new NullPointerException();
-                }
-            })
-            .immutable()
-            .build();
 
     final AttributeSet attributes;
 
     MultimapConfiguration(AttributeSet attributes) {
         this.attributes = attributes;
-    }
-
-    static AttributeSet attributeDefinitionSet() {
-        return new AttributeSet(MultimapConfiguration.class, NAME);
     }
 
     public boolean supportsDuplicates() {
@@ -32,9 +20,5 @@ public class MultimapConfiguration {
 
     public AttributeSet attributes() {
         return attributes;
-    }
-
-    public String name() {
-        return attributes.attribute(NAME).get();
     }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
@@ -2,22 +2,39 @@ package org.infinispan.multimap.configuration;
 
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
-import org.infinispan.configuration.cache.Configuration;
 
-public class MultimapConfiguration extends Configuration {
+public class MultimapConfiguration {
 
-    static final AttributeDefinition<Boolean> SUPPORTS_DUPLICATES = AttributeDefinition.builder(Attribute.SUPPORTS_DUPLICATES, false, Boolean.class)
+    public static final AttributeDefinition<Boolean> SUPPORTS_DUPLICATES = AttributeDefinition.builder(Attribute.SUPPORTS_DUPLICATES, false, Boolean.class)
             .immutable().build();
+    static final AttributeDefinition<String> NAME = AttributeDefinition.builder(Attribute.NAME, null, String.class)
+            .validator(value -> {
+                if (value == null) {
+                    throw new NullPointerException();
+                }
+            })
+            .immutable()
+            .build();
 
     final AttributeSet attributes;
 
     MultimapConfiguration(AttributeSet attributes) {
-        // FIXME: create constructor
         this.attributes = attributes;
     }
 
+    static AttributeSet attributeDefinitionSet() {
+        return new AttributeSet(MultimapConfiguration.class, NAME);
+    }
 
     public boolean supportsDuplicates() {
         return attributes.attribute(SUPPORTS_DUPLICATES).get();
+    }
+
+    public AttributeSet attributes() {
+        return attributes;
+    }
+
+    public String name() {
+        return attributes.attribute(NAME).get();
     }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfiguration.java
@@ -2,37 +2,22 @@ package org.infinispan.multimap.configuration;
 
 import org.infinispan.commons.configuration.attributes.AttributeDefinition;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
+import org.infinispan.configuration.cache.Configuration;
 
-public class MultimapConfiguration {
+public class MultimapConfiguration extends Configuration {
 
-    static final AttributeDefinition<String> NAME = AttributeDefinition.builder(Attribute.NAME, null, String.class)
-            .validator(value -> {
-                if (value == null) {
-                    try {
-                        throw new Exception("Missing name");
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-            })
-            .immutable()
-            .build();
+    static final AttributeDefinition<Boolean> SUPPORTS_DUPLICATES = AttributeDefinition.builder(Attribute.SUPPORTS_DUPLICATES, false, Boolean.class)
+            .immutable().build();
 
     final AttributeSet attributes;
 
     MultimapConfiguration(AttributeSet attributes) {
+        // FIXME: create constructor
         this.attributes = attributes;
     }
 
-    static AttributeSet attributeDefinitionSet() {
-        return new AttributeSet(MultimapConfiguration.class, NAME);
-    }
 
-    final AttributeSet attributes() {
-        return attributes;
-    }
-
-    public String name() {
-        return attributes.attribute(NAME).get();
+    public boolean supportsDuplicates() {
+        return attributes.attribute(SUPPORTS_DUPLICATES).get();
     }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationBuilder.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationBuilder.java
@@ -4,15 +4,11 @@ import org.infinispan.commons.configuration.Builder;
 import org.infinispan.commons.configuration.attributes.Attribute;
 import org.infinispan.commons.configuration.attributes.AttributeSet;
 
+import static org.infinispan.multimap.configuration.MultimapConfiguration.SUPPORTS_DUPLICATES;
+
 public class MultimapConfigurationBuilder implements Builder<MultimapConfiguration> {
 
     private final AttributeSet attributes = MultimapConfiguration.attributeDefinitionSet();
-
-    @Override
-    public Builder<?> read(MultimapConfiguration template) {
-        this.attributes.read(template.attributes());
-        return this;
-    }
 
     @Override
     public void validate() {
@@ -21,12 +17,22 @@ public class MultimapConfigurationBuilder implements Builder<MultimapConfigurati
 
     @Override
     public MultimapConfiguration create() {
-        //FIXME
-        return new MultimapConfiguration();
+        return new MultimapConfiguration(attributes.protect());
     }
 
-    public MultimapConfigurationBuilder supportsDuplicates(boolean supportsDuplicates){
-        attributes.attribute(MultimapConfiguration.SUPPORTS_DUPLICATES).set(supportsDuplicates);
+    @Override
+    public Builder<?> read(MultimapConfiguration template) {
+        this.attributes.read(template.attributes());
+        return this;
+    }
+
+    public MultimapConfigurationBuilder name(String name) {
+        attributes.attribute(MultimapConfiguration.NAME).set(name);
+        return this;
+    }
+
+    public MultimapConfigurationBuilder supportsDuplicates(boolean supportsDuplicates) {
+        attributes.attribute(SUPPORTS_DUPLICATES).set(supportsDuplicates);
         return this;
     }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationBuilder.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationBuilder.java
@@ -1,0 +1,22 @@
+package org.infinispan.multimap.configuration;
+
+import org.infinispan.commons.configuration.Builder;
+import org.infinispan.configuration.cache.Configuration;
+
+public class MultimapConfigurationBuilder implements Builder<Configuration> {
+
+    @Override
+    public Configuration create() {
+        return null;
+    }
+
+    @Override
+    public Builder<?> read(Configuration template) {
+        return null;
+    }
+
+    @Override
+    public void validate() {
+        Builder.super.validate();
+    }
+}

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationBuilder.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationBuilder.java
@@ -1,22 +1,32 @@
 package org.infinispan.multimap.configuration;
 
 import org.infinispan.commons.configuration.Builder;
-import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.commons.configuration.attributes.Attribute;
+import org.infinispan.commons.configuration.attributes.AttributeSet;
 
-public class MultimapConfigurationBuilder implements Builder<Configuration> {
+public class MultimapConfigurationBuilder implements Builder<MultimapConfiguration> {
 
-    @Override
-    public Configuration create() {
-        return null;
-    }
+    private final AttributeSet attributes = MultimapConfiguration.attributeDefinitionSet();
 
     @Override
-    public Builder<?> read(Configuration template) {
-        return null;
+    public Builder<?> read(MultimapConfiguration template) {
+        this.attributes.read(template.attributes());
+        return this;
     }
 
     @Override
     public void validate() {
-        Builder.super.validate();
+        attributes.attributes().forEach(Attribute::validate);
+    }
+
+    @Override
+    public MultimapConfiguration create() {
+        //FIXME
+        return new MultimapConfiguration();
+    }
+
+    public MultimapConfigurationBuilder supportsDuplicates(boolean supportsDuplicates){
+        attributes.attribute(MultimapConfiguration.SUPPORTS_DUPLICATES).set(supportsDuplicates);
+        return this;
     }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationParser.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationParser.java
@@ -1,10 +1,7 @@
 package org.infinispan.multimap.configuration;
 
 import org.infinispan.commons.configuration.io.ConfigurationReader;
-import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
-import org.infinispan.configuration.parsing.ConfigurationParser;
-import org.infinispan.configuration.parsing.Namespace;
-import org.infinispan.configuration.parsing.Parser;
+import org.infinispan.configuration.parsing.*;
 import org.kohsuke.MetaInfServices;
 
 import static org.infinispan.multimap.configuration.MultimapConfigurationParser.NAMESPACE;
@@ -23,12 +20,15 @@ public class MultimapConfigurationParser implements ConfigurationParser {
 
     @Override
     public Namespace[] getNamespaces() {
-        return new Namespace[0];
+        return ParseUtils.getNamespaceAnnotations(getClass());
     }
 
     private void parseMultimapAttribute(Attribute attribute, String value, MultimapConfigurationBuilder builder) {
-        if (attribute == Attribute.SUPPORTS_DUPLICATES) {
-            builder.supportsDuplicates(Boolean.parseBoolean(value));
+        switch (attribute) {
+            case NAME:
+            case SUPPORTS_DUPLICATES:
+                builder.supportsDuplicates(Boolean.parseBoolean(value));
+                break;
         }
     }
 }

--- a/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationParser.java
+++ b/multimap/src/main/java/org/infinispan/multimap/configuration/MultimapConfigurationParser.java
@@ -1,0 +1,34 @@
+package org.infinispan.multimap.configuration;
+
+import org.infinispan.commons.configuration.io.ConfigurationReader;
+import org.infinispan.configuration.parsing.ConfigurationBuilderHolder;
+import org.infinispan.configuration.parsing.ConfigurationParser;
+import org.infinispan.configuration.parsing.Namespace;
+import org.infinispan.configuration.parsing.Parser;
+import org.kohsuke.MetaInfServices;
+
+import static org.infinispan.multimap.configuration.MultimapConfigurationParser.NAMESPACE;
+
+@MetaInfServices
+@Namespace(root = "multimap")
+@Namespace(uri = NAMESPACE + "*", root = "multimap", since = "14.0")
+public class MultimapConfigurationParser implements ConfigurationParser {
+
+    static final String NAMESPACE = Parser.NAMESPACE + "multimap:";
+
+    @Override
+    public void readElement(ConfigurationReader reader, ConfigurationBuilderHolder holder) {
+
+    }
+
+    @Override
+    public Namespace[] getNamespaces() {
+        return new Namespace[0];
+    }
+
+    private void parseMultimapAttribute(Attribute attribute, String value, MultimapConfigurationBuilder builder) {
+        if (attribute == Attribute.SUPPORTS_DUPLICATES) {
+            builder.supportsDuplicates(Boolean.parseBoolean(value));
+        }
+    }
+}

--- a/multimap/src/main/java/org/infinispan/multimap/impl/EmbeddedMultimapCacheManager.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/EmbeddedMultimapCacheManager.java
@@ -4,9 +4,13 @@ import java.util.Collection;
 
 import org.infinispan.Cache;
 import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.manager.EmbeddedCacheManager;
 import org.infinispan.multimap.api.embedded.MultimapCache;
 import org.infinispan.multimap.api.embedded.MultimapCacheManager;
+import org.infinispan.multimap.configuration.MultimapConfiguration;
+
+import static org.infinispan.multimap.impl.MultimapModuleLifecycle.MULTIMAP_CACHE_NAME;
 
 /**
  * Embedded implementation of {@link MultimapCacheManager}
@@ -25,6 +29,27 @@ public class EmbeddedMultimapCacheManager<K, V> implements MultimapCacheManager<
    @Override
    public Configuration defineConfiguration(String name, Configuration configuration) {
       return cacheManager.defineConfiguration(name, configuration);
+   }
+
+   @Override
+   public Configuration defineConfiguration(String name, MultimapConfiguration configuration) {
+      Configuration build = new ConfigurationBuilder()
+            // add encoding protostream
+            .build();
+      // we add the configuration of the cache in the multimap configuration cache
+      cacheManager.getCache(MULTIMAP_CACHE_NAME).putIfAbsent(name, configuration);
+
+      // we define the configuration of the multimap using the cache configuration
+      return cacheManager.defineConfiguration(name, build);
+   }
+
+   @Override
+   public MultimapCache<K, V> get(String name) {
+      Cache<K, Collection<V>> cache = cacheManager.getCache(name, true);
+      Cache<String, MultimapConfiguration> multimaps = cacheManager.getCache(MULTIMAP_CACHE_NAME);
+      MultimapConfiguration multimapConfig = multimaps.get(name);
+      EmbeddedMultimapCache multimapCache = new EmbeddedMultimapCache(cache, multimapConfig.supportsDuplicates());
+      return multimapCache;
    }
 
    @Override

--- a/multimap/src/main/java/org/infinispan/multimap/impl/MultimapModuleLifecycle.java
+++ b/multimap/src/main/java/org/infinispan/multimap/impl/MultimapModuleLifecycle.java
@@ -1,44 +1,28 @@
 package org.infinispan.multimap.impl;
 
-import java.util.Map;
-
-import org.infinispan.commons.marshall.AdvancedExternalizer;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfiguration;
 import org.infinispan.factories.GlobalComponentRegistry;
 import org.infinispan.factories.annotations.InfinispanModule;
 import org.infinispan.lifecycle.ModuleLifecycle;
-import org.infinispan.marshall.protostream.impl.SerializationContextRegistry;
-import org.infinispan.multimap.impl.function.ContainsFunction;
-import org.infinispan.multimap.impl.function.GetFunction;
-import org.infinispan.multimap.impl.function.PutFunction;
-import org.infinispan.multimap.impl.function.RemoveFunction;
+import org.infinispan.registry.InternalCacheRegistry;
+
+import java.util.EnumSet;
 
 /**
- * MultimapModuleLifecycle is necessary for the Multimap Cache module.
- * Registers advanced externalizers.
+ * Multimap module configuration
  *
- * @author Katia Aresti - karesti@redhat.com
- * @since 9.2
+ * @since 14.0
  */
 @InfinispanModule(name = "multimap", requiredModules = "core")
 public class MultimapModuleLifecycle implements ModuleLifecycle {
-
-   private static void addAdvancedExternalizer(Map<Integer, AdvancedExternalizer<?>> map, AdvancedExternalizer<?> ext) {
-      map.put(ext.getId(), ext);
-   }
+   public static final String MULTIMAP_CACHE_NAME = "org.infinispan.MULTIMAPS";
 
    @Override
    public void cacheManagerStarting(GlobalComponentRegistry gcr, GlobalConfiguration globalConfiguration) {
-      SerializationContextRegistry ctxRegistry = gcr.getComponent(SerializationContextRegistry.class);
-      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.PERSISTENCE, new PersistenceContextInitializerImpl());
-      ctxRegistry.addContextInitializer(SerializationContextRegistry.MarshallerType.GLOBAL, new PersistenceContextInitializerImpl());
-
-      final Map<Integer, AdvancedExternalizer<?>> externalizerMap = globalConfiguration.serialization()
-            .advancedExternalizers();
-
-      addAdvancedExternalizer(externalizerMap, PutFunction.EXTERNALIZER);
-      addAdvancedExternalizer(externalizerMap, RemoveFunction.EXTERNALIZER);
-      addAdvancedExternalizer(externalizerMap, ContainsFunction.EXTERNALIZER);
-      addAdvancedExternalizer(externalizerMap, GetFunction.EXTERNALIZER);
+      InternalCacheRegistry internalCacheRegistry = gcr.getComponent(InternalCacheRegistry.class);
+      internalCacheRegistry.registerInternalCache(MULTIMAP_CACHE_NAME, new ConfigurationBuilder()
+            .build(), EnumSet.of(InternalCacheRegistry.Flag.EXCLUSIVE));
    }
+
 }

--- a/multimap/src/main/resources/infinispan-multimap-config-14.0.xsd
+++ b/multimap/src/main/resources/infinispan-multimap-config-14.0.xsd
@@ -2,20 +2,20 @@
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.0"
            targetNamespace="urn:infinispan:config:multimap:14.0"
            xmlns:tns="urn:infinispan:config:multimap:14.0"
-           xmlns:config="urn:infinispan:config:14.0"
            xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:import namespace="urn:infinispan:config:14.0"
-               schemaLocation="https://infinispan.org/schemas/infinispan-config-14.0.xsd" />
 
     <xs:complexType name="multimap">
-        <xs:complexContent>
-            <xs:extension base="config:distributed-cache">
-                <xs:attribute name="supports-duplicates" type="xs:boolean" default="false">
-                    <xs:annotation>
-                        <xs:documentation>Determines if the multimap supports duplicates in the values. True or false (default).</xs:documentation>
-                    </xs:annotation>
-                </xs:attribute>
-            </xs:extension>
-        </xs:complexContent>
+        <xs:attribute name="name" type="xs:ID" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    Sets the clustered lock's name. It must be unique.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="supports-duplicates" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>Determines if the multimap supports duplicates in the values. True or false (default).</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 </xs:schema>

--- a/multimap/src/main/resources/infinispan-multimap-config-14.0.xsd
+++ b/multimap/src/main/resources/infinispan-multimap-config-14.0.xsd
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" version="1.0"
+           targetNamespace="urn:infinispan:config:multimap:14.0"
+           xmlns:tns="urn:infinispan:config:multimap:14.0"
+           xmlns:config="urn:infinispan:config:14.0"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:import namespace="urn:infinispan:config:14.0"
+               schemaLocation="https://infinispan.org/schemas/infinispan-config-14.0.xsd" />
+
+    <xs:complexType name="multimap">
+        <xs:complexContent>
+            <xs:extension base="config:distributed-cache">
+                <xs:attribute name="supports-duplicates" type="xs:boolean" default="false">
+                    <xs:annotation>
+                        <xs:documentation>Determines if the multimap supports duplicates in the values. True or false (default).</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/multimap/src/main/resources/infinispan-multimap-config-14.0.xsd
+++ b/multimap/src/main/resources/infinispan-multimap-config-14.0.xsd
@@ -8,7 +8,7 @@
         <xs:attribute name="name" type="xs:ID" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    Sets the clustered lock's name. It must be unique.
+                    Sets the Multimap's name. It must be unique.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>


### PR DESCRIPTION
The current implementation detail needs providing with a cache for the multimaps configuration.

A multimap internally is stored as a distributed cache. That's fine.
however, to make the difference between a multimap and a normal cache, the current implementation detail will hold the name of the mutimap as a key and the configuration of the multimap as a value (the configuration of the multimap).
this way infinispan will know how to check if a cache is actually meant to be used as a multimap or not.

The information of multimaps is held in a intrnal cache as for counters or locks. This internal cache will hold  the configuration of a particular multimap and the name of it. 
